### PR TITLE
Improved pairwise choice, give points to equal candidates

### DIFF
--- a/sc.py
+++ b/sc.py
@@ -243,7 +243,11 @@ class Aggregator():
                         candidate_points -= 1
                 if candidate_points > 0:
                     points[candidate] += 1
+                elif candidate_points < 0:
+                    points[rival] += 1
                 else:
+                    print(candidate_points)
+                    points[candidate] += 1
                     points[rival] += 1
 
         print('Pairwise comparison points:', points)


### PR DESCRIPTION
When two candidates score a draw (equal number of wins / candidate_points = 0), then both candidates should get a point.
(Could also be none. But not always a point for the rival).